### PR TITLE
Update openssl_seal call with 5th param now mandatory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "adrianbarbos/omnipay-mobilpay",
-    "description": "MobilPay driver for the Omnipay PHP payment processing library",
+    "name": "dark4ce/omnipay-mobilpay",
+    "description": "MobilPay driver for the Omnipay PHP payment processing library (updated version of adrianbarbos/omnipay-mobilpay)",
     "keywords": [
         "mobilpay",
         "gateway",

--- a/src/BusinessMastery/Mobilpay/Api/Request/AbstractRequest.php
+++ b/src/BusinessMastery/Mobilpay/Api/Request/AbstractRequest.php
@@ -314,7 +314,7 @@ abstract class AbstractRequest
         $encData    = null;
         $envKeys    = null;
 
-        $result    = openssl_seal($srcData, $encData, $envKeys, $publicKeys);
+        $result    = openssl_seal($srcData, $encData, $envKeys, $publicKeys, 'RC4');
         if ($result === false) {
             $this->outEncData    = null;
             $this->outEnvKey    = null;


### PR DESCRIPTION
Hi Adrian,

I am using your mobilpay library and I have just updated to PHP 8.0 and now it seems that the 5th param of openssl_seal is no longer optional. I have updated the call to include it.

Thank you,
Catalin.